### PR TITLE
typo and SyntaxError, correction?

### DIFF
--- a/build/lib/Pdf2TextLibrary/__init__.py
+++ b/build/lib/Pdf2TextLibrary/__init__.py
@@ -8,7 +8,7 @@ class Pdf2TextLibrary(object):
     ROBOT_LIBRARY_SCOPE = 'Global'
 
     def __init__(self):
-        print 'pdt to text library'
+        print('pdf to text library')
 
     def convert_pdf_to_txt(self,path):
         rsrcmgr = PDFResourceManager()


### PR DESCRIPTION
Modification to repair this error:
Extracting robotframework_pdf2textlibrary-0.3-py3.8.egg to c:\python3\lib\site-packages
  File "c:\python3\lib\site-packages\robotframework_pdf2textlibrary-0.3-py3.8.egg\Pdf2TextLibrary\__init__.py", line 11
    print 'pdt to text library'
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print('pdt to text library')?